### PR TITLE
ENH - Add missing repos to the sync

### DIFF
--- a/.github/ISSUE_TEMPLATE/RFD.md
+++ b/.github/ISSUE_TEMPLATE/RFD.md
@@ -9,14 +9,14 @@ title: "RFD - Title"
 <!-- Example of when and how to create a RFD or RFC (request for comments) -->
 <!-- https://gitpod.notion.site/Decision-Making-RFCs-eb4a57f3a34f40f1afbd95e05322af70 -->
 
-<!-- Use this guide to set the status: Draft 🚧 / Open for comments 💬/ Accepted ✅ /Implemented 🚀/ Obsolete 🗃  -->
+<!-- Use this guide to set the status: Draft 🚧 / Open for comments 💬/ Accepted ✅ /Implemented 🚀/ Obsolete 🗃 /  Rejected ⛔️ -->
 
-| Status            | Draft 🚧 / Open for comments 💬/ Accepted ✅ /Implemented 🚀/ Obsolete 🗃 |
-| ----------------- | ------------------------------------------------------------------------ |
-| Author(s)         | GitHub handle                                                            |
-| Date Created      | dd-MM-YYY                                                                |
-| Date Last updated | dd-MM-YYY                                                                |
-| Decision deadline | dd-MM-YYY                                                                |
+| Status            | Draft 🚧 / Open for comments 💬/ Accepted ✅ /Implemented 🚀/ Obsolete 🗃 / Rejected ⛔️ |
+| ----------------- | --------------------------------------------------------------------------------------- |
+| Author(s)         | GitHub handle                                                                           |
+| Date Created      | dd-MM-YYY                                                                               |
+| Date Last updated | dd-MM-YYY                                                                               |
+| Decision deadline | dd-MM-YYY                                                                               |
 
 # Title
 

--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -8,6 +8,8 @@ group:
         exclude: |
           bug-report.yml
           bug-report-nebari.yml
+          RFD.md
+        deleteOrphaned: true
       - source: LICENSE
         dest: LICENSE
       - source: CONTRIBUTING.md
@@ -18,6 +20,8 @@ group:
       nebari-dev/docker-images
       nebari-dev/governance
       nebari-dev/nebari-jupyterhub-theme
+      nebari-dev/nebari-deploy
+      nebari-dev/nebari-demo
 
   # finer grained bug report issues - Nebari
   - files:
@@ -35,6 +39,8 @@ group:
       nebari-dev/docker-images
       nebari-dev/governance
       nebari-dev/nebari-jupyterhub-theme
+      nebari-dev/nebari-deploy
+      nebari-dev/nebari-demo
 
   # pull request template - adds the documentation section
   - files:
@@ -45,6 +51,8 @@ group:
       nebari-dev/docker-images
       nebari-dev/governance
       nebari-dev/nebari-jupyterhub-theme
+      nebari-dev/nebari-deploy
+      nebari-dev/nebari-demo
 
   # pull request template - without the documentation section
   - files:
@@ -52,3 +60,10 @@ group:
         dest: .github/PULL_REQUEST_TEMPLATE.md
     repos: |
       nebari-dev/nebari
+
+  # RFD - should only be in the governance repo
+  - files:
+      - source: .github/ISSUE_TEMPLATE/RFD.md
+        dest: .github/ISSUE_TEMPLATE/RFD.md
+    repos: |
+      nebari-dev/governance


### PR DESCRIPTION
This PR adds the following

- adds nebari-demo and nebari-deploy to the sync file
- ensures that deleted files in the source repo are also deleted in the other synced ones
- move RFD so that this only lives in the governance repo

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

