### PR TITLE
fix: handle issues/PRs with no priority label in sync workflow

### DIFF
--- a/.github/workflows/sync-project-priority.yaml
+++ b/.github/workflows/sync-project-priority.yaml
@@ -86,7 +86,7 @@ jobs:
           LABELS: ${{ toJSON(github.event.issue.labels || github.event.pull_request.labels) }}
         run: |
           set -uo pipefail
-          PRIORITY=$(echo "$LABELS" | jq -r '.[].name' | grep -oE '^priority: [a-zA-Z]+' | head -1 | awk '{print $2}')
+          PRIORITY=$(echo "$LABELS" | jq -r '[.[].name | capture("^priority: (?<p>[a-zA-Z]+)") | .p][0] // ""')
 
           if [ -z "$PRIORITY" ]; then
             echo "No priority label; clearing field."


### PR DESCRIPTION
## Summary

Fixes a crash in the `sync-project-priority.yaml` reusable workflow when an issue or PR has no `priority: *` label (or no labels at all). In that case the step exits with code 1 before the "no priority label; clearing field" branch can run, so callers see a spurious red ❌ on PRs / issues that simply don't need a priority set.

Spotted on [nebari-dev/nebari-data-science-pack#46](https://www.github.com/nebari-dev/nebari-data-science-pack/pull/46) — the `Add to project / sync` check is failing because that PR has no `priority: *` label (by design — it's a small chore-style fix).

## Root cause

In the `Apply priority from labels` step:

```bash
set -uo pipefail
PRIORITY=$(echo "$LABELS" | jq -r '.[].name' | grep -oE '^priority: [a-zA-Z]+' | head -1 | awk '{print $2}')

if [ -z "$PRIORITY" ]; then
  echo "No priority label; clearing field."
  ...
```

GitHub Actions' default shell is `bash --noprofile --norc -e -o pipefail {0}`, so `set -e` and `pipefail` are already active before the script's own `set -uo pipefail` runs. When `LABELS` is `[]` (or contains no priority label), `jq -r '.[].name'` emits nothing, and `grep -oE` exits **1** because nothing matches. `pipefail` propagates that 1, `set -e` kills the step, and the `if [ -z "$PRIORITY" ]` branch that was supposed to handle this case is never reached — note the missing `"No priority label; clearing field."` line in the failing log.

## Changes

### `.github/workflows/sync-project-priority.yaml`

Replace the `jq | grep | head | awk` pipeline with a single `jq` expression that captures the priority name and defaults to an empty string when there's no match:

```bash
PRIORITY=$(echo "$LABELS" | jq -r '[.[].name | capture("^priority: (?<p>[a-zA-Z]+)") | .p][0] // ""')
```

- No external `grep`/`awk` processes.
- Always exits 0, so the downstream `if [ -z "$PRIORITY" ]` branch is actually reachable.
- Same matching semantics (alphabetic token after `priority: `), and it still handles the real label format in use (e.g. `priority: low 🌱`).

## Before / After

```bash
# Before — LABELS=[]
$ PRIORITY=$(echo '[]' | jq -r '.[].name' | grep -oE '^priority: [a-zA-Z]+' | head -1 | awk '{print $2}')
$ echo $?
1    # pipefail + set -e → step fails

# After — LABELS=[]
$ PRIORITY=$(echo '[]' | jq -r '[.[].name | capture("^priority: (?<p>[a-zA-Z]+)") | .p][0] // ""')
$ echo "[$PRIORITY] exit=$?"
[] exit=0    # falls through to the "no priority label; clearing field" branch

# After — LABELS=[{"name":"priority: low 🌱"}]
$ PRIORITY=$(echo '[{"name":"priority: low 🌱"}]' | jq -r '[.[].name | capture("^priority: (?<p>[a-zA-Z]+)") | .p][0] // ""')
$ echo "[$PRIORITY]"
[low]
```

## Test plan

- [x] Validated manually against four inputs: empty labels, priority-only, non-priority labels only, priority label with emoji suffix — all exit 0 and extract the expected value.
- [ ] Confirm the workflow now passes on a PR with no priority label (e.g. nebari-data-science-pack#46) after this is merged.
