### PR TITLE
docs: fork-safe usage for sync-project-priority + fix dead README links

### DIFF
--- a/.github/workflows/sync-project-priority.yaml
+++ b/.github/workflows/sync-project-priority.yaml
@@ -3,24 +3,32 @@ name: Sync project priority from labels
 # Reusable workflow: adds an issue or PR to a Projects v2 board and syncs the
 # Priority single-select field based on labels of the form "priority: <level>".
 #
-# Triggered by caller repos on issues/pull_request events (opened, labeled, unlabeled).
-# The caller passes the project's GraphQL node ID and a PAT with project: write scope.
+# Triggered by caller repos on issues and pull_request_target events
+# (opened, labeled, unlabeled). The caller passes the project's GraphQL node ID
+# and a PAT with project: write scope.
+#
+# Note: callers must use pull_request_target (not pull_request) for the PR
+# trigger. PRs opened from forks do not receive secrets under pull_request, so
+# the PAT would be empty and the job would fail. pull_request_target runs in the
+# base repo's context, making the secret available. This is safe because this
+# workflow checks out no PR code — it only reads trusted event metadata
+# (node_id, labels) and calls the GitHub API.
 
 on:
   workflow_call:
     inputs:
       project-id:
-        description: 'GraphQL node ID of the project (e.g. PVT_kwDOBd3CI84BKoKt)'
+        description: "GraphQL node ID of the project (e.g. PVT_kwDOBd3CI84BKoKt)"
         required: true
         type: string
       priority-field-name:
-        description: 'Name of the single-select field holding priority'
+        description: "Name of the single-select field holding priority"
         required: false
         type: string
-        default: 'Priority'
+        default: "Priority"
     secrets:
       token:
-        description: 'PAT with project: write and repo: read scopes'
+        description: "PAT with project: write and repo: read scopes"
         required: true
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -9,9 +9,34 @@ This is a meta-repository that defines some shared files for the repositories un
 Below is a quick list of what you'll find in this repository:
 
 - `.github/ISSUE_TEMPLATE/`: Issue templates for other repositories. When these files are changed, they are automatically synced to our other repositories via [this GitHub action](.github/workflows/sync-issue-templates.yaml).
-- `.github/PULL_REQUEST_TEMPLATE.md`: Pull request templates for other repositories. When these files are changed, they are automatically synced to our other repositories via [this GitHub action](.github/workflows/sync-pull-request-templates.yaml).
-- `LICENSE`: All of our projects are under a BSD-3 clause license, this is automatically synced to our other repositories via [this GitHub action](.github/workflows/sync-pull-request-templates.yaml).
-- `CONTRIBUTING.md`: Base contributing guidelines for all of our projects, this is automatically synced to our other repositories via [this GitHub action](.github/workflows/sync-pull-request-templates.yaml).
+- `.github/PULL_REQUEST_TEMPLATE.md`: Pull request templates for other repositories. When these files are changed, they are automatically synced to our other repositories via [this GitHub action](.github/workflows/sync-issue-templates.yaml).
+- `LICENSE`: All of our projects are under a BSD-3 clause license, this is automatically synced to our other repositories via [this GitHub action](.github/workflows/sync-issue-templates.yaml).
+- `CONTRIBUTING.md`: Base contributing guidelines for all of our projects, this is automatically synced to our other repositories via [this GitHub action](.github/workflows/sync-issue-templates.yaml).
+
+> **Note**
+> The file-syncing above is all driven by the single [`sync-issue-templates.yaml`](.github/workflows/sync-issue-templates.yaml) workflow, configured via [`.github/sync.yml`](.github/sync.yml) using [`BetaHuhn/repo-file-sync-action`](https://github.com/BetaHuhn/repo-file-sync-action).
+
+## :arrows_counterclockwise: Reusable workflows
+
+- [`.github/workflows/sync-project-priority.yaml`](.github/workflows/sync-project-priority.yaml): Reusable workflow (`workflow_call`) that adds an issue/PR to a Projects v2 board and syncs a `Priority` single-select field from `priority: <level>` labels. Caller repos invoke it on their issue and pull request events, passing the project's GraphQL node ID and a PAT with `project: write` scope:
+
+  ```yaml
+  on:
+    issues:
+      types: [opened, labeled, unlabeled]
+    pull_request_target:
+      types: [opened, labeled, unlabeled]
+  jobs:
+    sync:
+      uses: nebari-dev/.github/.github/workflows/sync-project-priority.yaml@main
+      with:
+        project-id: <PVT_…>
+      secrets:
+        token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+  ```
+
+  > **Note**
+  > For the PR trigger, callers must use `pull_request_target`, **not** `pull_request`. PRs opened from forks do not receive secrets under `pull_request`, so the PAT is empty and the job fails. `pull_request_target` runs in the base repo's context, making the secret available. This is safe because the workflow checks out no PR code — it only reads trusted event metadata and calls the GitHub API.
 
 > **Warning**
 > The syncing action requires a Personal Authentication Token (PAT) which is currently set up through [Nebari-sensei](https://github.com/nebari-sensei)


### PR DESCRIPTION
## What

Documentation-only changes to the reusable `sync-project-priority.yaml` workflow and the README.

### 1. `sync-project-priority.yaml` header comment

The header told callers to trigger on `pull_request`. That breaks for PRs opened from **forks**: GitHub withholds secrets from `pull_request` runs on cross-repo PRs, so the passed PAT is empty, `GH_TOKEN` is blank, and the job fails on its first `gh api` call.

Updated the comment to require **`pull_request_target`** for the PR trigger and explain why it's safe — this workflow checks out no PR code, it only reads trusted event metadata (`node_id`, `labels`) and calls the GitHub API.

### 2. README

- **New "Reusable workflows" section** documenting `sync-project-priority.yaml` with a correct caller snippet (using `pull_request_target`) and the fork-secrets note.
- **Fixed three dead links.** The entries for `PULL_REQUEST_TEMPLATE.md`, `LICENSE`, and `CONTRIBUTING.md` all linked to `.github/workflows/sync-pull-request-templates.yaml`, which doesn't exist. All file syncing is actually driven by the single `sync-issue-templates.yaml` workflow via `.github/sync.yml` (`BetaHuhn/repo-file-sync-action`). Repointed the links and added a note clarifying this.

## Why now

A caller repo hit the fork failure in practice (companion fix: https://redirect.github.com/nebari-dev/nebari-infrastructure-core/pull/359). This PR makes the guidance here match reality so the next caller avoids the trap.

## Notes

- Prettier (the repo's pre-commit hook) normalized the YAML string quotes to double quotes; no behavior change.